### PR TITLE
Add a config target for each daemon that builds the config.

### DIFF
--- a/daemons/Makefile
+++ b/daemons/Makefile
@@ -9,23 +9,27 @@ chainedawslambdatargets := chained-aws-lambda-s3-parallel-copy-supervisor \
                            chained-aws-lambda-fasttest \
                            chained-aws-lambda-supervisortest \
 
+chainedawslambdaconfigtargets := $(addsuffix .config, $(chainedawslambdatargets))
+
 chained-aws-lambda: $(chainedawslambdatargets)
-$(chainedawslambdatargets): chained-aws-lambda-%:
-	rm -rf $@
-	cp -rf chained-aws-lambda $@
+$(chainedawslambdatargets): chained-aws-lambda-%: chained-aws-lambda-%.config
+	cd chained-aws-lambda-$*; domovoi deploy --stage dev
+
+$(chainedawslambdaconfigtargets): chained-aws-lambda-%.config :
+	rm -rf chained-aws-lambda-$*
+	cp -rf chained-aws-lambda chained-aws-lambda-$*
 	python ../scripts/chained_aws_lambda.py $(account_id) \
 	  --enable-s3-parallel-copy-supervisor --s3-parallel-copy-supervisor-lambda-name chained-aws-lambda-s3-parallel-copy-supervisor-dev \
 	  --enable-s3-parallel-copy-worker --s3-parallel-copy-worker-lambda-name chained-aws-lambda-s3-parallel-copy-worker-dev \
 	  --enable-s3-copy --s3-copy-lambda-name chained-aws-lambda-s3-copy-dev \
 	  --enable-fasttest --fasttest-lambda-name chained-aws-lambda-fasttest-dev \
 	  --enable-supervisortest --supervisortest-lambda-name chained-aws-lambda-supervisortest-dev \
-	  --$*-policy-path $@/.chalice/policy.json --$*-app-path $@/app.py
+	  --$*-policy-path chained-aws-lambda-$*/.chalice/policy.json --$*-app-path chained-aws-lambda-$*/app.py
 
-	cat chained-aws-lambda/.chalice/config.json | jq '.app_name="$@"' > $@/.chalice/config.json
+	cat chained-aws-lambda/.chalice/config.json | jq '.app_name="chained-aws-lambda-$*"' > chained-aws-lambda-$*/.chalice/config.json
 	# blindly enable access to our test S3 bucket.  This is ok since most daemons require it anyway.
-	cat $@/.chalice/policy.json | jq -f s3_enable.filter | sponge $@/.chalice/policy.json
-	cp -R ../src/chainedawslambda $@/domovoilib
-	./build_deploy_config.sh $@ dev
-	cd $@; domovoi deploy --stage dev
+	cat chained-aws-lambda-$*/.chalice/policy.json | jq -f s3_enable.filter | sponge chained-aws-lambda-$*/.chalice/policy.json
+	cp -R ../src/chainedawslambda chained-aws-lambda-$*/domovoilib
+	./build_deploy_config.sh chained-aws-lambda-$* dev
 
-.PHONY: chained-aws-lambda $(chainedawslambdatargets)
+.PHONY: chained-aws-lambda $(chainedawslambdatargets) $(chainedawslambdaconfigtargets)


### PR DESCRIPTION
The idea is that we can introduce a makefile rule between the config generation and the deployment that alters a *specific* daemon.